### PR TITLE
Use clearInterval in Ping#stop

### DIFF
--- a/lib/ping.js
+++ b/lib/ping.js
@@ -37,7 +37,7 @@ Ping.prototype.start = function start () {
 
 Ping.prototype.stop = function stop () {
   debug('stop()')
-  clearTimeout(this.intervalToken)
+  clearInterval(this.intervalToken)
   this.intervalToken = undefined
   this.socket.close()
 }


### PR DESCRIPTION
I've done this before. `clearTimeout` won't clear an interval, but it won't complain either, just keeps the process alive :O