### PR TITLE
Allow options to be passed into Ping

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,18 @@ discover.start()
 // discover.stop()
 ```
 
+## Options to HarmonyHubDiscover
+
+HarmonyHubDiscover takes an optional `options` argument that allows you to specify parameters to the discovery packet that is sent out:
+* `address`: the broadcast address to send the discovery packet to, defaults to `255.255.255.255`. On systems with multiple interfaces, you need to specify the broadcast address of the network your Hub is connected to. For example, if the Hub is connected to 192.168.1.0/24, specify address `192.168.1.255`.
+* `interval`: the number of milliseconds between sending out discovery packets. Defaults to `1000`.
+* `port`: The port to send the discovery packet to. Defaults to `5224`.
+
+Example:
+```javascript
+var discover = new HarmonyHubDiscover(61991, { 'address': '192.168.1.255' })
+```
+
 ## Control your hub
 After looking up your Harmony hub, use [harmonyhubjs-client](https://github.com/swissmanu/harmonyhubjs-client) to control it.
 

--- a/lib/explorer.js
+++ b/lib/explorer.js
@@ -54,13 +54,13 @@ function executeCleanUp () {
   })
 }
 
-function Explorer (port) {
+function Explorer (port, pingOptions) {
   debug('Explorer(' + port + ')')
   EventEmitter.call(this)
 
   this.knownHubs = {}
   this.port = port
-  this.ping = new Ping(this.port)
+  this.ping = new Ping(this.port, pingOptions)
 }
 util.inherits(Explorer, EventEmitter)
 

--- a/lib/ping.js
+++ b/lib/ping.js
@@ -1,13 +1,14 @@
 var debug = require('debug')('harmonyhubjs:discover:ping')
 var dgram = require('dgram')
 
-function Ping (portToAnnounce) {
-  debug('Ping(' + portToAnnounce + ')')
+function Ping (portToAnnounce, options) {
+  options = options || {}
+  debug('Ping(' + portToAnnounce + ', ' + JSON.stringify(options) + ')')
 
   this.socket = dgram.createSocket('udp4')
-  this.port = 5224
-  this.address = '255.255.255.255'
-  this.interval = 1000
+  this.port = options.port || 5224
+  this.address = options.address || '255.255.255.255'
+  this.interval = options.interval || 1000
   this.message = '_logitech-reverse-bonjour._tcp.local.\n' + portToAnnounce
   this.messageBuffer = new Buffer(this.message)
 
@@ -37,7 +38,7 @@ Ping.prototype.start = function start () {
 
 Ping.prototype.stop = function stop () {
   debug('stop()')
-  clearTimeout(this.intervalToken)
+  clearInterval(this.intervalToken)
   this.intervalToken = undefined
   this.socket.close()
 }


### PR DESCRIPTION
This allows users to specify the broadcast address to send the ping to.
This is neccessary on systems with more than one interface, or certain
operating systems.

This allows KraigM/homebridge-harmonyhub#105 to be addressed.