### PR TITLE
Listen for error events on all established connection, because they w…

### DIFF
--- a/lib/ping.js
+++ b/lib/ping.js
@@ -16,6 +16,11 @@ function Ping (portToAnnounce, options) {
   this.socket.bind(this.port, function () {
     this.setBroadcast(true)
   })
+  // Listen for potential errors, because otherwise errors are thrown.
+  // (They appear to be harmless in practice for our use.)
+  this.socket.on('error', function (err) {
+    debug('error during socket bind: ' + err)
+  })
 }
 
 function emit () {

--- a/lib/responseCollector.js
+++ b/lib/responseCollector.js
@@ -30,6 +30,11 @@ ResponseCollector.prototype.start = function start () {
       debug('connection closed. emitting data.')
       self.emit('response', buffer)
     })
+
+    // Listen for potential errors, because otherwise errors are thrown.
+    socket.on('error', function (err) {
+      debug('error with connection: ' + err)
+    })
   }).listen(self.port)
 }
 


### PR DESCRIPTION
…ill be thrown otherwise.

Thrown errors will terminate the process, which is quite harmful when using this
library on always-on devices.
For the ResponseCollector, we may consider to add proper reconnect handling in
the future. That's not implemented here.